### PR TITLE
complete the all tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = space
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
+    - nightly
 
 before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar --dev install --prefer-source
+    - composer install
 
-script: phpunit
+script:
+    - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+after_success:
+    - php vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -14,19 +14,27 @@
     ],
 
     "autoload": {
-        "psr-0": {
-            "PHPCommons": "src/",
-            "Tests": "tests/"
+        "psr-4": {
+            "PHPCommons\\Exception\\": "src/PHPCommons/Exception",
+            "PHPCommons\\Lang\\": "src/PHPCommons/Lang"
+        }
+    },
+
+    "autoload-dev": {
+        "psr-4": {
+            "PHPCommons\\Lang\\": "tests/PHPCommons/Lang"
         }
     },
 
     "minimum-stability": "stable",
 
     "require": {
-        "php":  ">=5.3.2"
+        "php":  ">=5.4",
+        "ext-mbstring": "*"
     },
 
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "^4.8",
+        "php-coveralls/php-coveralls": "dev-master || ^1.0"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,13 +8,9 @@
     </testsuites>
 
     <filter>
-        <whitelist>
-            <directory suffix=".php">src/pascaldevink/PHPCommons</directory>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">src/</directory>
         </whitelist>
-        <blacklist>
-            <directory>tests</directory>
-            <directory>vendor</directory>
-        </blacklist>
     </filter>
 
     <logging>

--- a/src/PHPCommons/Lang/StringUtils.php
+++ b/src/PHPCommons/Lang/StringUtils.php
@@ -5,7 +5,7 @@ namespace PHPCommons\Lang;
 use PHPCommons\Exception\NotAStringException;
 
 /**
- * 
+ *
  * @author pascaldevink
  */
 class StringUtils
@@ -28,13 +28,13 @@ class StringUtils
      */
     public function isEmpty($str)
     {
-        if ($str == null) {
+        if ($str === null) {
             return true;
         }
         if (!is_string($str)) {
             throw new NotAStringException();
         }
-        if ($str == "") {
+        if ($str === "") {
             return true;
         }
 
@@ -332,7 +332,7 @@ class StringUtils
             return self::INDEX_NOT_FOUND;
         }
 
-        if (!is_int($startPos) || $startPos < 0) {
+        if (!is_int($startPos)) {
             $startPos = 0;
         }
 
@@ -369,7 +369,7 @@ class StringUtils
                 $str = substr($str, 0, $pos);
             }
             else if ($i == 0) {
-                $wordPos == self::INDEX_NOT_FOUND;
+                $wordPos = self::INDEX_NOT_FOUND;
             }
         }
 

--- a/tests/PHPCommons/Lang/StringUtilsTest.php
+++ b/tests/PHPCommons/Lang/StringUtilsTest.php
@@ -2,7 +2,9 @@
 
 namespace PHPCommons\Lang;
 
-class StringUtilsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class StringUtilsTest extends TestCase
 {
     /** @var StringUtils */
     private $stringUtils;
@@ -34,6 +36,14 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->stringUtils->isEmpty(123);
         $this->stringUtils->isEmpty(array());
         $this->stringUtils->isEmpty(12323.323);
+    }
+
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testTrimWithInvalidString()
+    {
+        $this->stringUtils->trim(123);
     }
 
     public function testIsNotEmpty()
@@ -122,6 +132,14 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("ab c", $this->stringUtils->strip(" ab c "));
     }
 
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testStripWithInvalidString()
+    {
+        $this->stringUtils->strip(123);
+    }
+
     public function testStripWithCharlist()
     {
         $this->assertEquals("  abc", $this->stringUtils->strip("  abcyx", "xyz"));
@@ -159,6 +177,14 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("abc  ",$this->stringUtils->stripStart("yxabc  ", "xyz"));
     }
 
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testStripStartWithInvalidString()
+    {
+        $this->stringUtils->stripStart(123);
+    }
+
     public function testStripEnd()
     {
         $this->assertNull($this->stringUtils->stripEnd(null));
@@ -166,6 +192,14 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("abc",  $this->stringUtils->stripEnd("abc  "));
         $this->assertEquals("  abc",$this->stringUtils->stripEnd("  abcxy", "xyz"));
         $this->assertEquals("12",   $this->stringUtils->stripEnd("120.00", ".0"));
+    }
+
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testStripEndWithInvalidString()
+    {
+        $this->stringUtils->stripEnd(123);
     }
 
     public function testEquals()
@@ -177,6 +211,16 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->stringUtils->equals("abc", "ABC"));
     }
 
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testEqualsWithInvalidString()
+    {
+        $this->stringUtils->equals(123, 123);
+        $this->stringUtils->equals(123, '123');
+        $this->stringUtils->equals('123', 123);
+    }
+
     public function testEqualsIgnoreCase()
     {
         $this->assertTrue($this->stringUtils->equalsIgnoreCase(null, null));
@@ -185,6 +229,16 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->stringUtils->equalsIgnoreCase("abc", "abc"));
         $this->assertTrue($this->stringUtils->equalsIgnoreCase("abc", "ABC"));
     }
+
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testEqualsIgnoreCaseWithInvalidString()
+    {
+        $this->stringUtils->equalsIgnoreCase(123, 123);
+        $this->stringUtils->equalsIgnoreCase(123, '123');
+        $this->stringUtils->equalsIgnoreCase('123', 123);
+    }   
 
     public function testIndexOf()
     {
@@ -204,6 +258,16 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2,  $this->stringUtils->indexOf("aabaabaa", 'b', 'b'));
     }
 
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testIndexOfWithInvalidString()
+    {
+        $this->stringUtils->indexOf(123, 123);
+        $this->stringUtils->indexOf(123, '123');
+        $this->stringUtils->indexOf('123', 123);
+    }
+
     public function testOrdinalIndexOf()
     {
         $this->assertEquals(-1, $this->stringUtils->ordinalIndexOf(null, null, null));
@@ -216,6 +280,16 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(4,  $this->stringUtils->ordinalIndexOf("aabaabaa", "ab", 2));
         $this->assertEquals(0,  $this->stringUtils->ordinalIndexOf("aabaabaa", "", 1));
         $this->assertEquals(0,  $this->stringUtils->ordinalIndexOf("aabaabaa", "", 2));
+    }
+
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testOrdinalIndexOfWithInvalidString()
+    {
+        $this->stringUtils->ordinalIndexOf(123, 123);
+        $this->stringUtils->ordinalIndexOf(123, '123');
+        $this->stringUtils->ordinalIndexOf('123', 123);
     }
 
     public function testIndexOfIgnoreCase()
@@ -236,6 +310,16 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(-1,  $this->stringUtils->indexOfIgnoreCase("abc", "", 9));
     }
 
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testIndexOfIgnoreCaseWithInvalidString()
+    {
+        $this->stringUtils->indexOfIgnoreCase(123, 123);
+        $this->stringUtils->indexOfIgnoreCase(123, '123');
+        $this->stringUtils->indexOfIgnoreCase('123', 123);
+    }
+
     public function testLastIndexOf()
     {
         $this->assertEquals(-1, $this->stringUtils->lastIndexOf(null, null));
@@ -245,16 +329,32 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(5,  $this->stringUtils->lastIndexOf("aabaabaa", 'b', 8));
         $this->assertEquals(1,  $this->stringUtils->lastIndexOf("aabaabaa", 'b', 4));
-        $this->assertEquals(5, $this->stringUtils->lastIndexOf("aabaabaa", 'b', 0));
+        $this->assertEquals(5,  $this->stringUtils->lastIndexOf("aabaabaa", 'b', 0));
         $this->assertEquals(5,  $this->stringUtils->lastIndexOf("aabaabaa", 'b', 9));
         $this->assertEquals(-1, $this->stringUtils->lastIndexOf("aabaabaa", 'b', -1));
         $this->assertEquals(7,  $this->stringUtils->lastIndexOf("aabaabaa", 'a', 0));
 
-        $this->assertEquals(7, $this->stringUtils->lastIndexOf("aabaabaa", "a"));
-        $this->assertEquals(5, $this->stringUtils->lastIndexOf("aabaabaa", "b"));
-        $this->assertEquals(4, $this->stringUtils->lastIndexOf("aabaabaa", "ab"));
+        $this->assertEquals(7,  $this->stringUtils->lastIndexOf("aabaabaa", "a"));
+        $this->assertEquals(5,  $this->stringUtils->lastIndexOf("aabaabaa", "b"));
+        $this->assertEquals(4,  $this->stringUtils->lastIndexOf("aabaabaa", "ab"));
         $this->assertEquals(-1, $this->stringUtils->lastIndexOf("aabaabaa", ""));
     }
+
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testLastIndexOfWithInvalidString()
+    {
+        $this->stringUtils->lastIndexOf(123, 123);
+        $this->stringUtils->lastIndexOf(123, '123');
+        $this->stringUtils->lastIndexOf('123', 123);  
+    }    
+
+    public function testLastIndexOfWithInvalidStartPos()
+    {
+        $this->assertEquals(-1, $this->stringUtils->lastIndexOf('123', '123', -1));
+        $this->assertEquals(-1, $this->stringUtils->lastIndexOf('123', '123', 1.23));
+    }    
 
     public function testLastOrdinalIndexOf()
     {
@@ -268,6 +368,21 @@ class StringUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1,  $this->stringUtils->lastOrdinalIndexOf("aabaabaa", "ab", 2));
         $this->assertEquals(-1, $this->stringUtils->lastOrdinalIndexOf("aabaabaa", "", 1));
     }
+
+    /**
+     * @expectedException PHPCommons\Exception\NotAStringException
+     */
+    public function testLastOrdinalIndexOfWithInvalidString()
+    {
+        $this->stringUtils->lastOrdinalIndexOf(123, 123);
+        $this->stringUtils->lastOrdinalIndexOf(123, '123');
+        $this->stringUtils->lastOrdinalIndexOf('123', 123);  
+    }
+
+    public function testLastOrdinalIndexOfWithNoSearchString()
+    {
+        $this->assertEquals(-1, $this->stringUtils->lastOrdinalIndexOf('123', 'no_search_string'));
+    } 
 
     public function testLastIndexOfIgnoreCase()
     {


### PR DESCRIPTION
# Changed log
- change the required PHP version is 5.4+.
- set proper settings in ```.travis.yml```.
- add ```.editorconfig``` to organize the basic coding style.
- integrate the code coverage service coveralls in this repo tests.
- use the completed equal to check empty string in ```isEmpty``` method because the null empty string will be the same condtion for the valuec-based equal.
- modify the incorrect condition in ```lastIndexOf``` method.
- see more details about the [Travis build](https://travis-ci.org/peter279k/php-commons) and [code coverage report](https://coveralls.io/github/peter279k/php-commons) from coveralls.

## TODO
- implement the missing methods in ```StringUtils``` class.